### PR TITLE
Install with pip instead of setup.py

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -72,7 +72,7 @@ install_version() {
 
   cd ${install_path}/tmp/${TOOL_NAME}-${version}
 
-  python setup.py install
+  pip install .
 
   cd ${install_path}
 


### PR DESCRIPTION
Avoids this failure:

```
Processing MarkupSafe-2.0.1.tar.gz
Writing /var/folders/vg/rt3sgxfx6r951049hx0jl2ww0000gn/T/easy_install-rblekrdk/MarkupSafe-2.0.1/setup.cfg
Running MarkupSafe-2.0.1/setup.py -q bdist_egg --dist-dir /var/folders/vg/rt3sgxfx6r951049hx0jl2ww0000gn/T/easy_install-rblekrdk/MarkupSafe-2.0.1/egg-dist-tmp-pjh_2s0q
no previously-included directories found matching 'docs/_build'
warning: no previously-included files matching '*.pyc' found anywhere in distribution
zip_safe flag not set; analyzing archive contents...
markupsafe.__pycache__._speedups.cpython-39: module references __file__
No eggs found in /var/folders/vg/rt3sgxfx6r951049hx0jl2ww0000gn/T/easy_install-rblekrdk/MarkupSafe-2.0.1/egg-dist-tmp-pjh_2s0q (setup script problem?)
error: The 'MarkupSafe>=2.0' distribution was not found and is required
by jinja2, Jinja2
```

(I'll be honest... I'm not sure why, but it does!)
